### PR TITLE
Revise and improve instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ iCESugar-pro
 * [Reference](#reference)
 
 # iCESugar-pro
-iCESugar-pro is a FPGA board base on Lattice LFE5U-25F-6BG256C, which is fully supported by the open source toolchain (yosys & nextpnr), the board is designed in DDR2 SODIMM form with 106 usable IOs, with on-board 32MB SDRAM, it can run RISC-V Linux. the on board debugger iCELink (base on ARM Mbed DAPLink) support drag-and-drop program, you can just drag the FPGA bitstream into the virtual disk to program, and with a additional USB CDC serial port direct connect to FPGA, so you can only use one TYPE-C cable to develop and test.  
+iCESugar-pro is a FPGA development board based on Lattice LFE5U-25F-6BG256C, which is fully supported by the open source toolchain (yosys & nextpnr), the board is designed in DDR2 SODIMM form factor with 106 usable IOs, with on-board 32MB SDRAM, it can run RISC-V Linux. The on-board iCELink debugger (base on ARM Mbed DAPLink) supports drag-and-drop programming, you can just drag the FPGA bitstream into the virtual disk to program, and with a additional USB CDC serial port direct connect to FPGA, so you can only use one TYPE-C cable to develop and test.  
 <div align=center>
 <img src="https://github.com/wuxx/icesugar-pro/blob/master/doc/iCESugar-pro-1.jpg" width = "700" alt="" align=center />    
 <img src="https://github.com/wuxx/icesugar-pro/blob/master/doc/iCESugar-pro-2.jpg" width = "700" alt="" align=center />    
@@ -34,24 +34,24 @@ LFE5U-25F-6BG256C (BGA256 0.8mm pitch)
 6. PLL x 1
 
 ### SDRAM
- SDRAM use IS42S16160B (32MB)
+ SDRAM uses IS42S16160B (32MB)
 
 ### SPI-Flash
- SPI Flash use W25Q256JV (32MB)
+ SPI Flash uses W25Q256JV (32MB)
 
 ### Clock
-a 25MHz crystal is connect to P6
+A 25MHz crystal is connect to P6
 
 ### Peripheral
 2. a RGB LED is connected to {A11, A12, B11}
 3. a SDCARD slot, support SPI/SDIO
-4. 106 usable IOs out with SODIMM-DDR2-200P, can use with ext-board.
+4. 106 usable IOs out with SODIMM-DDR2-200P, broken out with the ext-board.
 
 ### JTAG
-the native JTAG of ECP5 is connect to the on-board iCELink, you can flash bistream with this JTAG interface (called JTAG1).
-and there is also another JTAG interface (actually just some GPIOs of ECP5) connect to the iCELink too (called JTAG2),
-if you design a SoC with a JTAG interface support, then you can use the JTAG2 to debug your SoC. only one JTAG work a one moment.
-so use the icesprog tool with command `icesprog -j 1 or 2` to switch between these two JTAG interface.
+The native JTAG of ECP5 is connect to the on-board iCELink, you can flash bitstream with this JTAG interface (called JTAG1).
+There is also another JTAG interface (actually, just some GPIOs of ECP5) connected to the iCELink too (called JTAG2),
+if you design a SoC with a JTAG interface support, then you can use the JTAG2 to debug your SoC. Only one JTAG works at once.
+So use the icesprog tool with command `icesprog -j 1 or 2` to switch between these two JTAG interface.
 ```
 $icesprog -j 1
 JTAG --> [JTAG-1]
@@ -71,8 +71,8 @@ done
 ```
 
 ### iCELink
-iCESugar-pro has a on board debugger named iCELink (base on APM32F1)，you can only use one USB wire to program the FPGA and debug, here is detail:   
-1. drag-and-drop program, just drop the bitstream into the virtual USB DISK iCELink, then wait a few second, the iCELink firmware will do the total program work
+iCESugar-pro has a on-board debugger named iCELink (base on APM32F1)，you can only use one USB wire to program the FPGA and debug, here is detail:   
+1. drag-and-drop program, just drop the bitstream into the virtual USB DISK iCELink, then wait a few second, the iCELink firmware will program it for you.
 2. USB CDC serial port, it can use to communicate with FPGA
 3. 2 JTAG interfaces for flash the ECP5 or debug the SoC on ECP5
 4. use the command tool `icesprog` to flash or do more config, here is the help info
@@ -102,26 +102,24 @@ $icesprog -g PA14 -m out
 $icesprog -g PA14 -w 0
 ```
 
-#### How-To-Program
+#### How To Program
 there are multiple ways to program the bitstream.
 1. drag-and-drop program, this may be the fastest and simplest way to flash.  
 2. use the command `icesprog xxx.bit`, this can provide more configable parameters.  
 3. use the command `dapprog xxx.bit (program to flash) or dapprog xxx.svf (program to SRAM)`  
 the `icesprog` binary and source code is in [icesugar](https://github.com/wuxx/icesugar/tree/master/tools) repo, and the `dapprog` is a bash wrapper of openocd command, click [here](https://github.com/wuxx/icesugar-pro/tree/master/tools) to check how to setup.
 
-# virtual-machine-image
+# Virtual machine image
 link：https://pan.baidu.com/s/1vV2ckFpOuyd600Y47Tl1sw  
 verify code：i3en  
 `user: ubuntu`  
-`passwd: ubuntu`  
-or
-https://mega.nz/file/uvJTWKrK#1bBgBkJPZrszwHQSTHHL-RLjxGIru0Qv0qUgmULZZVs
+`passwd: ubuntu`
 
-the env include yosys, nextpnr, icestorm, gcc, sbt.
+The env include yosys, nextpnr, icestorm, gcc, sbt.
 
-# How-to-setup-env
+# How to setup enviroment
 ## Linux
-recommend use the virtual machine, it simple and convenient  
+It is reccomended that you use the virtual machine image, it simple and convenient  
 FPGA toolchain reference [icestorm](http://www.clifford.at/icestorm/)  
 gcc toolchain reference [riscv-gnu-toolchain](https://pingu98.wordpress.com/2019/04/08/how-to-build-your-own-cpu-from-scratch-inside-an-fpga/)  
 Alternatively, you can download the pre-built toolchain provided by xPack or SiFive
@@ -132,22 +130,30 @@ Alternatively, you can download the pre-built toolchain provided by xPack or SiF
 `$sudo apt-get install libusb-1.0-0-dev`  
 
 ## Windows
-now you can use the msys2 environment to setup the open source toolchain easily, download msys2 install executable [here](https://www.msys2.org/), install it, then open the msys2 mingw terminal (search `msys2` in windows start menu)  
+If you don't want to use the virtual machine image you need to use the Windows Subsystem For Linux 2 (WSL2) as not all components of the toolchain has native windows versions.\
+Install WSL using [this tutorial.](https://learn.microsoft.com/en-us/windows/wsl/install) By default it uses ubuntu, which this section is written for. Once WSL is installed and configured you can open it by searching for 'WSL' from the start menu.\
+Once in the WSL desktop you will need to preform the following commands to install the needed toolkits.\
+### Yosys:
 ```
-#pacman -Syu
-#pacman -S mingw-w64-x86_64-eda
+sudo apt-get install build-essential clang bison flex \
+	libreadline-dev gawk tcl-dev libffi-dev git \
+	graphviz xdot pkg-config python3 libboost-system-dev \
+	libboost-python-dev libboost-filesystem-dev zlib1g-dev
 ```
-select the yosys, nextpnr, icestorm, icesprog and install, after installed, everything is same as in linux!
+### Nextpnr
+Download and extract the latest [nextpnr release](https://github.com/YosysHQ/nextpnr) and follow the instructions to build [nextpnr-ecp5](https://github.com/YosysHQ/nextpnr#nextpnr-ecp5) as the iCESugar-Pro is based on a ECP5 FPGA.
 
+### Other tools
+Dapprog is included in the tools folder and can be executed from there. ecpprog is included in the install for nextpnr and the RISC-V gcc toolchain used for code compilation can be installed using [this tutorial](https://github.com/riscv-collab/riscv-gnu-toolchain)
 
-# How-to-buy
-you can buy iCESugar-pro and PMOD peripherals from our offcial aliexpress shop [Muse Lab Factory Store](https://miusecn-muselab-tech.aliexpress.com/) or search `iCESugar-Pro FPGA` on [www.aliexpress.com](https://miusecntech-muselab.aliexpress.com/)
+# How to buy
+You can buy iCESugar-pro and PMOD peripherals from our offcial aliexpress shop [Muse Lab Factory Store](https://miusecn-muselab-tech.aliexpress.com/) or search `iCESugar-Pro FPGA` on [aliexpress.com](https://miusecntech-muselab.aliexpress.com/)
 
 # Copyright Statement
-the hdmi test verilog source code is from [https://github.com/DoctorWkt/ULX3S-Blinky](https://github.com/DoctorWkt/ULX3S-Blinky)  
-the linux related project is from [https://github.com/litex-hub/linux-on-litex-vexriscv](https://github.com/litex-hub/linux-on-litex-vexriscv)  
-for hobby and personal usage, you are free to use the iCESugar-pro, you can also make the board yourself by document & firmware in this repo.  
-for the commercial usage, if you got iCESugar-pro Board from our official shop and use in other commercial product, that's no problem, in other situation, please contact us in advance.  
+The HDMI test verilog source code is from [github.com/DoctorWkt/ULX3S-Blinky](https://github.com/DoctorWkt/ULX3S-Blinky)  
+The Litex on Linux project is from [github.com/litex-hub/linux-on-litex-vexriscv](https://github.com/litex-hub/linux-on-litex-vexriscv)  
+For hobby and personal usage, you are free to use the iCESugar-pro, you can also make the board yourself using the documentation & firmware in this repo.  
+For the commercial usage, if you get iCESugar-pro Board from our official shop and use in other commercial product, that's no problem, otherwise, please contact us in advance.  
 
 # Reference
 ### Colorlight-FPGA-Projects


### PR DESCRIPTION
Hello!

This commit, besides improving capitalization and phrasing where needed, reworks the windows install instructions as they were previously entirely nonfunctional (msys2 is for windows app creation and the pacman commands are for Arch Linux) and replaces it with a WSL2-based solution.
As for the removal of the mega link it is due to the fact that it no longer works.
For the Linux section, while I left it in, the Icestorm project is focused on the 40-series chips from Lattice (ex: the types included on the iCESugar and iCEStick boards from you and Lattice respectively) which differ from the ECP5 chips on the pro which are supported by Project Trellis that the nextpnr section of the windows install links to.

If there are any issues you have with this proposed edit I'd be glad to be notified of it.