### PR TITLE
Add build info and make toolkit install easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ iCESugar-pro
 	* [Peripheral](#peripheral)
 	* [JTAG](#jtag)
 	* [iCELink](#icelink)
-* [virtual-machine-image](#virtual-machine-image)
-* [How-to-setup](#how-to-setup-env)
-* [How-to-buy](#how-to-buy)
+* [Virtual machine image](#virtual-machine-image)
+* [How to setup](#how-to-setup-env)
+* [How to buy](#how-to-buy)
 * [Copyright Statement](#copyright-statement)
 * [Reference](#reference)
 
 # iCESugar-pro
-iCESugar-pro is a FPGA development board based on Lattice LFE5U-25F-6BG256C, which is fully supported by the open source toolchain (yosys & nextpnr), the board is designed in DDR2 SODIMM form factor with 106 usable IOs, with on-board 32MB SDRAM, it can run RISC-V Linux. The on-board iCELink debugger (base on ARM Mbed DAPLink) supports drag-and-drop programming, you can just drag the FPGA bitstream into the virtual disk to program, and with a additional USB CDC serial port direct connect to FPGA, so you can only use one TYPE-C cable to develop and test.  
+iCESugar-pro is a FPGA development board based on Lattice LFE5U-25F-6BG256C, which is fully supported by the open source toolchain (yosys & nextpnr), the board is designed in DDR2 SODIMM form factor with 106 usable IOs, with on-board 32MB SDRAM, it can run RISC-V Linux. The on-board iCELink debugger (base on ARM Mbed DAPLink) supports drag-and-drop programming, you can just drag the FPGA bitstream into the virtual disk to program, and with a additional USB CDC serial port direct connect to FPGA, so you can only use one Type C cable to develop and test.  
 <div align=center>
 <img src="https://github.com/wuxx/icesugar-pro/blob/master/doc/iCESugar-pro-1.jpg" width = "700" alt="" align=center />    
 <img src="https://github.com/wuxx/icesugar-pro/blob/master/doc/iCESugar-pro-2.jpg" width = "700" alt="" align=center />    
@@ -71,10 +71,10 @@ done
 ```
 
 ### iCELink
-iCESugar-pro has a on-board debugger named iCELink (base on APM32F1)，you can only use one USB wire to program the FPGA and debug, here is detail:   
-1. drag-and-drop program, just drop the bitstream into the virtual USB DISK iCELink, then wait a few second, the iCELink firmware will program it for you.
+iCESugar-pro has a on-board debugger named iCELink (base on APM32F1)，only needing one USB wire to program the FPGA and debug it:   
+1. Drag and drop programming, just drop the bitstream into the virtual USB drive named iCELink then wait a few seconds while the iCELink firmware programs it for you.
 2. USB CDC serial port, it can use to communicate with FPGA
-3. 2 JTAG interfaces for flash the ECP5 or debug the SoC on ECP5
+3. 2 JTAG interfaces for flashing the ECP5 or debugging your SoC on ECP5
 4. use the command tool `icesprog` to flash or do more config, here is the help info
 ```
 $icesprog -h
@@ -103,10 +103,10 @@ $icesprog -g PA14 -w 0
 ```
 
 #### How To Program
-there are multiple ways to program the bitstream.
-1. drag-and-drop program, this may be the fastest and simplest way to flash.  
-2. use the command `icesprog xxx.bit`, this can provide more configable parameters.  
-3. use the command `dapprog xxx.bit (program to flash) or dapprog xxx.svf (program to SRAM)`  
+There are multiple ways to program the bitstream.
+1. Drag and drop programming, this is the fastest and simplest way to flash.  
+2. Using the command `icesprog xxx.bit`, this can provide more configable parameters.  
+3. Using the command `dapprog xxx.bit (program to flash) or dapprog xxx.svf (program to SRAM)`  
 the `icesprog` binary and source code is in [icesugar](https://github.com/wuxx/icesugar/tree/master/tools) repo, and the `dapprog` is a bash wrapper of openocd command, click [here](https://github.com/wuxx/icesugar-pro/tree/master/tools) to check how to setup.
 
 # Virtual machine image
@@ -119,32 +119,26 @@ The env include yosys, nextpnr, icestorm, gcc, sbt.
 
 # How to setup enviroment
 ## Linux
-It is reccomended that you use the virtual machine image, it simple and convenient  
-FPGA toolchain reference [icestorm](http://www.clifford.at/icestorm/)  
-gcc toolchain reference [riscv-gnu-toolchain](https://pingu98.wordpress.com/2019/04/08/how-to-build-your-own-cpu-from-scratch-inside-an-fpga/)  
-Alternatively, you can download the pre-built toolchain provided by xPack or SiFive
-+ https://xpack.github.io/riscv-none-embed-gcc/install/
-+ https://www.sifive.com/software  
-`icesprog` is command tool for iCESugar program，it depend libusb and hidapi  
-`$sudo apt-get install libhidapi-dev`  
-`$sudo apt-get install libusb-1.0-0-dev`  
+It is reccomended that you use the virtual machine image, it simple and convenient.\
+Alternatively, you can download the toolchain for programming the FPGA unit by following the instructions in the "Installing Toolkits" section below and the RISC-V compiler for running your code has a tutorial linked in the "Other tools" section.
 
 ## Windows
 If you don't want to use the virtual machine image you need to use the Windows Subsystem For Linux 2 (WSL2) as not all components of the toolchain has native windows versions.\
 Install WSL using [this tutorial.](https://learn.microsoft.com/en-us/windows/wsl/install) By default it uses ubuntu, which this section is written for. Once WSL is installed and configured you can open it by searching for 'WSL' from the start menu.\
-Once in the WSL desktop you will need to preform the following commands to install the needed toolkits.\
-### Yosys:
-```
-sudo apt-get install build-essential clang bison flex \
-	libreadline-dev gawk tcl-dev libffi-dev git \
-	graphviz xdot pkg-config python3 libboost-system-dev \
-	libboost-python-dev libboost-filesystem-dev zlib1g-dev
-```
-### Nextpnr
-Download and extract the latest [nextpnr release](https://github.com/YosysHQ/nextpnr) and follow the instructions to build [nextpnr-ecp5](https://github.com/YosysHQ/nextpnr#nextpnr-ecp5) as the iCESugar-Pro is based on a ECP5 FPGA.
+Once in the WSL desktop you will need to preform the following commands to install the needed toolkits.
+
+## Installing Toolkits (Windows and Linux)
+The easiest way to get all needed tools is using the [YosysHQ oss-cad-suite](https://github.com/YosysHQ/oss-cad-suite-build). All you need to do is download and extract the repository to a location on your machine such as the home folder. After you extract it you'll need to update your PATH variable so your terminal can use the programs.\
+Do this by editing your `.bashrc` file on your home folder using `sudo nano .bashrc` from there. Scrolll to the end of the file and in a new line add `export PATH="$PATH:/home/YOUR_ACCOUNT_NAME_HERE/oss-cad-suite/bin"`
 
 ### Other tools
 Dapprog is included in the tools folder and can be executed from there. ecpprog is included in the install for nextpnr and the RISC-V gcc toolchain used for code compilation can be installed using [this tutorial](https://github.com/riscv-collab/riscv-gnu-toolchain)
+
+
+## Building demo files
+If you want to use the demo files as is you just need to program the bitstream provided in the [`demo`](./demo) folder. 
+<!-- The relative location allows this link to work both online and locally-->
+If you want to change how the demos behave you will need to rebuild them. For the blink, hdmi and uart tests you just need to run `make` in the same folder to update them with your changes. For the litex_linux demo you will need to have the [litex repository](https://github.com/litex-hub/linux-on-litex-vexriscv) downloaded locally and will need to modify the `top.ys` file where it lists `INSTALL_DIR` with the location you put the repo.
 
 # How to buy
 You can buy iCESugar-pro and PMOD peripherals from our offcial aliexpress shop [Muse Lab Factory Store](https://miusecn-muselab-tech.aliexpress.com/) or search `iCESugar-Pro FPGA` on [aliexpress.com](https://miusecntech-muselab.aliexpress.com/)

--- a/src/litex_linux/top.ys
+++ b/src/litex_linux/top.ys
@@ -1,7 +1,7 @@
 verilog_defaults -push
 verilog_defaults -add -defer
-read_verilog /home/pi/oss/litex/pythondata-cpu-vexriscv/pythondata_cpu_vexriscv/verilog/VexRiscv_Linux.v
-read_verilog /home/pi/oss/linux-on-litex-vexriscv/build/ulx3s/gateware/top.v
+read_verilog /home/INSTALL_DIR/litex/pythondata-cpu-vexriscv/pythondata_cpu_vexriscv/verilog/VexRiscv_Linux.v
+read_verilog /home/INSTALL_DIR/linux-on-litex-vexriscv/build/ulx3s/gateware/top.v
 verilog_defaults -pop
 attrmap -tocase keep -imap keep="true" keep=1 -imap keep="false" keep=0 -remove keep=0
 synth_ecp5   -json top.json -top top


### PR DESCRIPTION
Hello Again!

This update condensed the toolkit installation to the oss-cad-suite from YosysHQ as all programs are precompiled (reducing possible dependency issues) and simplified the process of getting everything installed for the user.
The modification of the top.ys file just makes it easier for users who want to compile their own modification of the litex project to diagnose issues as it was previously set to a folder on the system you built this on (pi/oss) which now will show in errors as `/INSTALL_DIR/`.

As to possible future commits I'm currently trying to figure out how to create a generic `.lpf` file that allows anyone wanting to build with just standard HDL instead of high level toolkits such as Migen or LiteX to be able to use a direct translation to the board IO similar to how the `litex_linux/top.v` file uses definitions like `user_led0` in the lpf to allow the same definitions in the verilog. If that file or similar already exists could you point it to me?
Thanks.